### PR TITLE
Fix a problem with displaying the Project Settings window

### DIFF
--- a/Platform/Editor/PlatformConfig.cs
+++ b/Platform/Editor/PlatformConfig.cs
@@ -277,7 +277,7 @@ namespace Pico.Platform.Editor
                 GUILayout.Space(5);
                 GUILayout.Label(new GUIContent(strBuildSettingText[(int) language], strBuildSettingHelpText[(int) language]));
 
-                GUIStyle style = "frameBox";
+                GUIStyle style = new GUIStyle("frameBox");
                 style.fixedWidth = frameWidth;
                 EditorGUILayout.BeginVertical(style);
 


### PR DESCRIPTION
### Problem

After opening the PICO Platform Settings window in the editor, all tabs in the Project Settings window became the same size as the Platform Settings window.

<img width="1349" height="791" alt="before" src="https://github.com/user-attachments/assets/329be553-4c48-4313-82e5-0ac7e53ed832" />


### Solution

In the script of the PICO Platform Settings editor window, getting the basic Unity Editor style "frameBox" has been changed to creating a new style instance with copying the basic one.

885061fe81f2b83b473150d0d353e1083d595397

<img width="1303" height="771" alt="after" src="https://github.com/user-attachments/assets/26dda877-7c07-49f2-9a03-282f45937fe6" />


_*To apply the fix after the window is broken, the editor needs to be restarted._